### PR TITLE
Allowing users of the library to tweak the reqwest client's timeout

### DIFF
--- a/thirtyfour/src/common/config.rs
+++ b/thirtyfour/src/common/config.rs
@@ -6,6 +6,7 @@ use crate::{
 use const_format::formatcp;
 use http::HeaderValue;
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Configuration options used by a `WebDriver` instance and the related `SessionHandle`.
 ///
@@ -19,6 +20,8 @@ pub struct WebDriverConfig {
     pub poller: Arc<dyn IntoElementPoller + Send + Sync>,
     /// The user agent to use when sending commands to the webdriver server.
     pub user_agent: HeaderValue,
+    /// The timeout duration for reqwest client requests.
+    pub reqwest_timeout: Duration,
 }
 
 impl Default for WebDriverConfig {
@@ -68,6 +71,7 @@ pub struct WebDriverConfigBuilder {
     keep_alive: bool,
     poller: Option<Arc<dyn IntoElementPoller + Send + Sync>>,
     user_agent: Option<WebDriverResult<HeaderValue>>,
+    reqwest_timeout: Duration
 }
 
 impl Default for WebDriverConfigBuilder {
@@ -83,6 +87,7 @@ impl WebDriverConfigBuilder {
             keep_alive: true,
             poller: None,
             user_agent: None,
+            reqwest_timeout: Duration::from_secs(120),
         }
     }
 
@@ -108,12 +113,20 @@ impl WebDriverConfigBuilder {
         self
     }
 
+    /// Set the reqwest timeout.
+    pub fn reqwest_timeout(mut self, timeout: Duration) -> Self {
+        self.reqwest_timeout = timeout;
+        self
+    }
+
+
     /// Build `WebDriverConfig` using builder options.
     pub fn build(self) -> WebDriverResult<WebDriverConfig> {
         Ok(WebDriverConfig {
             keep_alive: self.keep_alive,
             poller: self.poller.unwrap_or_else(|| Arc::new(ElementPollerWithTimeout::default())),
             user_agent: self.user_agent.transpose()?.unwrap_or(WebDriverConfig::DEFAULT_USER_AGENT),
+            reqwest_timeout: self.reqwest_timeout
         })
     }
 }

--- a/thirtyfour/src/web_driver.rs
+++ b/thirtyfour/src/web_driver.rs
@@ -96,6 +96,7 @@ impl WebDriver {
         C: Into<Capabilities>,
     {
 
+        // TODO: create builder
         #[cfg(feature = "reqwest")]
         let client = create_reqwest_client(config.reqwest_timeout);
         #[cfg(not(feature = "reqwest"))]

--- a/thirtyfour/src/web_driver.rs
+++ b/thirtyfour/src/web_driver.rs
@@ -95,9 +95,9 @@ impl WebDriver {
         S: Into<String>,
         C: Into<Capabilities>,
     {
-        // TODO: create builder and make timeout configurable.
+
         #[cfg(feature = "reqwest")]
-        let client = create_reqwest_client(std::time::Duration::from_secs(120));
+        let client = create_reqwest_client(config.reqwest_timeout);
         #[cfg(not(feature = "reqwest"))]
         let client = crate::session::http::null_client::create_null_client();
         Self::new_with_config_and_client(server_url, capabilities, config, client).await


### PR DESCRIPTION
## Changes Made

1. **Added `reqwest_timeout` **:
    - Introduced a new field `reqwest_timeout` in the `WebDriverConfig` struct to specify the timeout duration for the `reqwest` client.
    - Updated the `WebDriverConfigBuilder` to include methods for setting the `reqwest_timeout`.
    - Ensured that the default timeout is set to 120 seconds if not specified by the user.
2. **Updated `web_driver.rs`**:
    - Modified the `new_with_config` function to use the `reqwest_timeout` from the `WebDriverConfig` when creating the reqwest client

This change enhances the flexibility of the `WebDriver` by allowing users to configure the timeout for the `reqwest` client, making the library more adaptable to different use cases.